### PR TITLE
Refactor conv1d call to ensure consistent state handling

### DIFF
--- a/xlstm/blocks/slstm/layer.py
+++ b/xlstm/blocks/slstm/layer.py
@@ -132,9 +132,9 @@ class sLSTMLayer(nn.Module):
 
         if self.config.conv1d_kernel_size > 0:
             if return_last_state:
-                x_conv = self.conv1d(x, conv_state, return_last_state=return_last_state)
+                x_conv, conv_state = self.conv1d(x, conv_state, return_last_state=return_last_state)
             else:
-                x_conv, conv_state = self.conv1d(
+                x_conv = self.conv1d(
                     x, conv_state, return_last_state=return_last_state
                 )
             x_conv = self.conv_act_fn(x_conv)


### PR DESCRIPTION
- Switched the assignment of `x_conv` and `conv_state` based on `return_last_state` condition
- Ensured `conv_state` is assigned when `return_last_state` is True