### PR TITLE
MISC: Fix typo in assigning forget and input gates

### DIFF
--- a/xlstm/blocks/slstm/layer.py
+++ b/xlstm/blocks/slstm/layer.py
@@ -103,7 +103,7 @@ class sLSTMLayer(nn.Module):
         else:
             x_conv = x
 
-        i, f, z, o = (
+        f, i, z, o = (
             self.fgate(x_conv),
             self.igate(x_conv),
             self.zgate(x),


### PR DESCRIPTION
The forget and input gates were switched.
This one line PR fixes this typo.