### PR TITLE
Fix CUDA compiler flags in cuda_init.py

### DIFF
--- a/xlstm/blocks/slstm/src/cuda_init.py
+++ b/xlstm/blocks/slstm/src/cuda_init.py
@@ -101,7 +101,7 @@ def load(*, name, sources, extra_cflags=(), extra_cuda_cflags=(), **kwargs):
             "-res-usage",
             "--use_fast_math",
             "-O3",
-            "-Xptxas -O3",
+            "-Xptxas",
             "--extra-device-vectorization",
             *extra_cflags,
             *extra_cuda_cflags,


### PR DESCRIPTION
-option O3 was used twice so I remove it, 
-under windows, the cuda compiler reports this as a cmdline option error, so this is acutally a small bug