### PR TITLE
Make sLSTM checkpoints portable across backends (#127)

### DIFF
--- a/tests/test_slstm_backend_state_dict.py
+++ b/tests/test_slstm_backend_state_dict.py
@@ -1,0 +1,86 @@
+"""Regression tests for sLSTM cross-backend checkpoint loading (issue #127).
+
+The sLSTM cell stores its recurrent kernel and bias in a backend-specific
+internal layout. ``state_dict`` used to serialize those internal parameters
+directly, so a checkpoint saved with one backend could not be loaded into a
+cell using another backend. These tests run on CPU via ``skip_backend_init``.
+"""
+
+import pytest
+import torch
+
+from xlstm.blocks.slstm.cell import (
+    sLSTMCell_cuda,
+    sLSTMCell_vanilla,
+    sLSTMCellConfig,
+)
+
+
+def _external_weights(cell):
+    """Return the backend-agnostic (external) recurrent kernel and bias."""
+    return (
+        cell._recurrent_kernel_int2ext(cell._recurrent_kernel_),
+        cell._bias_int2ext(cell._bias_),
+    )
+
+
+def _randomize(cell):
+    with torch.no_grad():
+        cell._recurrent_kernel_.copy_(torch.randn_like(cell._recurrent_kernel_))
+        cell._bias_.copy_(torch.randn_like(cell._bias_))
+
+
+@pytest.mark.parametrize(
+    "src_cls,dst_cls",
+    [
+        (sLSTMCell_cuda, sLSTMCell_vanilla),
+        (sLSTMCell_vanilla, sLSTMCell_cuda),
+    ],
+)
+def test_state_dict_loads_across_backends(src_cls, dst_cls):
+    """A checkpoint saved with one backend loads into the other without error
+    and preserves the (canonical) weights."""
+    config = sLSTMCellConfig(hidden_size=16, num_heads=4)
+    src = src_cls(config, skip_backend_init=True)
+    _randomize(src)
+    dst = dst_cls(config, skip_backend_init=True)
+
+    missing, unexpected = dst.load_state_dict(src.state_dict(), strict=True)
+    assert missing == [] and unexpected == []
+
+    src_kernel, src_bias = _external_weights(src)
+    dst_kernel, dst_bias = _external_weights(dst)
+    assert torch.allclose(dst_kernel, src_kernel)
+    assert torch.allclose(dst_bias, src_bias)
+
+
+@pytest.mark.parametrize("cls", [sLSTMCell_vanilla, sLSTMCell_cuda])
+def test_state_dict_same_backend_round_trip(cls):
+    """Saving and reloading within the same backend keeps the internal weights
+    bit-for-bit identical."""
+    config = sLSTMCellConfig(hidden_size=16, num_heads=4)
+    src = cls(config, skip_backend_init=True)
+    _randomize(src)
+    dst = cls(config, skip_backend_init=True)
+
+    dst.load_state_dict(src.state_dict())
+    assert torch.allclose(dst._recurrent_kernel_, src._recurrent_kernel_)
+    assert torch.allclose(dst._bias_, src._bias_)
+
+
+@pytest.mark.parametrize("cls", [sLSTMCell_vanilla, sLSTMCell_cuda])
+def test_state_dict_loads_legacy_internal_checkpoint(cls):
+    """A legacy checkpoint stored in the internal layout still loads into a cell
+    of its original backend (backward compatibility)."""
+    config = sLSTMCellConfig(hidden_size=16, num_heads=4)
+    src = cls(config, skip_backend_init=True)
+    _randomize(src)
+    legacy = {
+        "_recurrent_kernel_": src._recurrent_kernel_.detach().clone(),
+        "_bias_": src._bias_.detach().clone(),
+    }
+
+    dst = cls(config, skip_backend_init=True)
+    dst.load_state_dict(legacy)
+    assert torch.allclose(dst._recurrent_kernel_, src._recurrent_kernel_)
+    assert torch.allclose(dst._bias_, src._bias_)

--- a/tests/test_slstm_backend_state_dict.py
+++ b/tests/test_slstm_backend_state_dict.py
@@ -69,6 +69,18 @@ def test_state_dict_same_backend_round_trip(cls):
 
 
 @pytest.mark.parametrize("cls", [sLSTMCell_vanilla, sLSTMCell_cuda])
+def test_state_dict_tensors_are_contiguous(cls):
+    """Exported tensors must be contiguous so serializers that require it (e.g.
+    ``safetensors.torch.save_file``) accept the state dict."""
+    config = sLSTMCellConfig(hidden_size=16, num_heads=4)
+    cell = cls(config, skip_backend_init=True)
+
+    state_dict = cell.state_dict()
+    assert state_dict["_recurrent_kernel_"].is_contiguous()
+    assert state_dict["_bias_"].is_contiguous()
+
+
+@pytest.mark.parametrize("cls", [sLSTMCell_vanilla, sLSTMCell_cuda])
 def test_state_dict_loads_legacy_internal_checkpoint(cls):
     """A legacy checkpoint stored in the internal layout still loads into a cell
     of its original backend (backward compatibility)."""

--- a/xlstm/blocks/slstm/cell.py
+++ b/xlstm/blocks/slstm/cell.py
@@ -262,10 +262,62 @@ class sLSTMCellBase(nn.Module):
 
         self.reset_parameters()
 
+        # Persist the backend-agnostic (external/canonical) layout in `state_dict` so
+        # checkpoints can be moved between backends (e.g. "cuda" <-> "vanilla"). The
+        # stored `_recurrent_kernel_`/`_bias_` parameters are kept in a backend-specific
+        # internal layout; without these hooks a checkpoint saved with one backend fails
+        # to load into another -- the recurrent kernel raises a size mismatch and the
+        # bias loads silently with a scrambled gate/head ordering. See issue #127.
+        self._register_state_dict_hook(sLSTMCellBase._state_dict_to_external_hook)
+        self._register_load_state_dict_pre_hook(
+            sLSTMCellBase._load_state_dict_to_internal_pre_hook, with_module=True
+        )
+
         if self.config.hidden_size % self.config.num_heads != 0:
             raise ValueError(
                 f"Hidden Size {self.config.hidden_size} must be divisible by head num {self.config.num_heads}"
             )
+
+    @staticmethod
+    def _state_dict_to_external_hook(module, state_dict, prefix, local_metadata):
+        """Store the recurrent kernel and bias in the backend-agnostic external layout."""
+        recurrent_kernel_key = prefix + "_recurrent_kernel_"
+        bias_key = prefix + "_bias_"
+        if recurrent_kernel_key in state_dict:
+            state_dict[recurrent_kernel_key] = module._recurrent_kernel_int2ext(
+                state_dict[recurrent_kernel_key]
+            )
+        if bias_key in state_dict:
+            state_dict[bias_key] = module._bias_int2ext(state_dict[bias_key])
+        return state_dict
+
+    @staticmethod
+    def _load_state_dict_to_internal_pre_hook(
+        module,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        """Convert an external-layout checkpoint to this backend's internal layout.
+
+        External tensors are identified by their rank (recurrent kernel: 4D, bias: 3D).
+        Legacy checkpoints saved in the internal layout (recurrent kernel: 3D, bias: 1D)
+        are left untouched so they still load into a cell of their original backend.
+        """
+        recurrent_kernel_key = prefix + "_recurrent_kernel_"
+        bias_key = prefix + "_bias_"
+        recurrent_kernel = state_dict.get(recurrent_kernel_key)
+        if recurrent_kernel is not None and recurrent_kernel.ndim == 4:
+            state_dict[recurrent_kernel_key] = module._recurrent_kernel_ext2int(
+                recurrent_kernel
+            )
+        bias = state_dict.get(bias_key)
+        if bias is not None and bias.ndim == 3:
+            state_dict[bias_key] = module._bias_ext2int(bias)
 
     def __repr__(self):
         return (

--- a/xlstm/blocks/slstm/cell.py
+++ b/xlstm/blocks/slstm/cell.py
@@ -283,12 +283,15 @@ class sLSTMCellBase(nn.Module):
         """Store the recurrent kernel and bias in the backend-agnostic external layout."""
         recurrent_kernel_key = prefix + "_recurrent_kernel_"
         bias_key = prefix + "_bias_"
+        # The external conversions can return non-contiguous views (the vanilla
+        # backend uses `permute`); materialize them so serializers that require
+        # contiguous tensors, e.g. `safetensors.torch.save_file`, accept the result.
         if recurrent_kernel_key in state_dict:
             state_dict[recurrent_kernel_key] = module._recurrent_kernel_int2ext(
                 state_dict[recurrent_kernel_key]
-            )
+            ).contiguous()
         if bias_key in state_dict:
-            state_dict[bias_key] = module._bias_int2ext(state_dict[bias_key])
+            state_dict[bias_key] = module._bias_int2ext(state_dict[bias_key]).contiguous()
         return state_dict
 
     @staticmethod


### PR DESCRIPTION
## What

Fixes #127. A checkpoint saved with one sLSTM backend cannot be loaded into a cell using another backend:

```python
from xlstm.blocks.slstm.cell import sLSTMCell_cuda, sLSTMCell_vanilla, sLSTMCellConfig
cfg = sLSTMCellConfig(hidden_size=16, num_heads=4)
cuda = sLSTMCell_cuda(cfg, skip_backend_init=True)
sLSTMCell_vanilla(cfg, skip_backend_init=True).load_state_dict(cuda.state_dict())
# RuntimeError: size mismatch for _recurrent_kernel_: ... torch.Size([4, 4, 16]) vs torch.Size([4, 16, 4])
```

## Why

`sLSTMCell_vanilla` and `sLSTMCell_cuda` keep the recurrent kernel and bias in **different internal layouts**:

| tensor | vanilla internal | cuda internal | canonical / external |
|---|---|---|---|
| recurrent kernel | `(H, G·head_dim, head_dim)` | `(H, head_dim, G·head_dim)` | `(H, head_dim, G, head_dim)` |
| bias | `(H·G·head_dim,)` gate-major | `(H·G·head_dim,)` head-major | `(H, G, head_dim)` |

`state_dict` serializes the **internal** `_recurrent_kernel_`/`_bias_` parameters directly. Loading across backends therefore fails: the recurrent kernel raises a size mismatch, and — more insidiously — the bias has the *same* flat shape in both backends, so it loads **without error but with a scrambled gate/head ordering** (silent weight corruption).

The cell already defines a single **canonical (external) layout** via its `_..._int2ext`/`_..._ext2int` conversions, exposes it through the `recurrent_kernel`/`bias` proxies, and `sLSTMCell_cuda.__init__` documents cross-backend conversion (`skip_backend_init`) as an intended workflow — so the checkpoint simply needs to be stored in that canonical layout.

## How

Two hooks registered in `sLSTMCellBase.__init__`:

- **`_register_state_dict_hook`** — on save, convert `_recurrent_kernel_`/`_bias_` to the canonical external layout (`int2ext`).
- **`_register_load_state_dict_pre_hook`** — on load, convert an external-layout checkpoint back into the current backend's internal layout (`ext2int`).

External tensors are identified by **rank** (recurrent kernel 4D, bias 3D). Legacy checkpoints saved in the old internal layout (recurrent kernel 3D, bias 1D) are left untouched, so they still load into a cell of their original backend — the change is backward compatible.

## Verification (CPU, via `skip_backend_init=True`)

- `cuda → vanilla` and `vanilla → cuda` now load with no error, and the canonical weights match exactly (`allclose`) — including the bias, which was previously corrupted silently.
- Same-backend save/load round-trips remain bit-for-bit identical.
- A legacy internal-layout checkpoint still loads into a cell of its original backend.

## Tests

`tests/test_slstm_backend_state_dict.py` covers all four cases above. The two cross-backend tests **fail on `main`** (`RuntimeError` / corrupted bias) and pass with the fix; same-backend and legacy tests pass both ways. They run on CPU.

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*