### PR TITLE
Mention xlstm.c under recommendations for other hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ If you are working inside Apple's MLX ecosystem, check out the community-driven
 [xLSTM-metal](https://github.com/MLXPorts/xLSTM-metal) port which provides an
 MLX-native implementation of xLSTM targeting Apple Silicon.
 
+If you are targeting embedded or bare-metal hardware, check out the
+community-driven [xlstm.c](https://github.com/raws-labs/xlstm.c), which
+implements the sLSTM and mLSTM cells in portable C99 with no framework,
+allocator or operating system, and has backends for Cortex-M, Helium and
+Xtensa.
+
 # Models from the xLSTM NeurIPS Paper
 
 This section explains how to use the models from the xLSTM paper.


### PR DESCRIPTION
Adds a sentence alongside the xLSTM-metal entry, for embedded and bare-metal targets.

xlstm.c implements the sLSTM and mLSTM cells in portable C99 - cells only, so pre-norm, conv1d, projections, GroupNorm, the residual and stacking stay caller-side. It is validated against reference vectors generated from this repository, at H = 1, 2, 8, 16, 17 and 64 in f32 and INT8, and verified on Cortex-M7, M4F and M33 silicon.

Happy to reword or drop it if you would rather keep that section to full-model implementations.