### PR TITLE
Dependencies: make xLSTM Large dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,7 @@ and shows promising performance on Language Modeling when compared to Transforme
 We refer to the optimized architecture for our xLSTM 7B as xLSTM Large. 
 
 ## Minimal Installation
-
-Create a conda environment from the file `environment_pt240cu124.yaml`.
-Install the model code only (i.e. the module `xlstm`) as package:
-
-For using the xLSTM Large 7B model install [`mlstm_kernels`](https://github.com/NX-AI/mlstm_kernels) via:
-``` 
-pip install mlstm_kernels
-```
-Then install the xlstm package via pip: 
+Install the xlstm package via pip:
 ```bash
 pip install xlstm
 ```
@@ -46,6 +38,12 @@ cd xlstm
 pip install -e .
 ```
 
+For using the xLSTM Large 7B model, install the `large` optional dependencies (including [`mlstm_kernels`](https://github.com/NX-AI/mlstm_kernels)):
+```bash
+pip install "xlstm[large]"
+```
+When installing from source, use `pip install -e ".[large]"` to include the xLSTM Large dependencies.
+
 ## Requirements
 
 This package is based on PyTorch and was tested for versions `>=1.8`. For a well-tested environment, install the `environment_pt240cu124.yaml` as:
@@ -54,7 +52,7 @@ conda env create -n xlstm -f environment_pt240cu124.yaml
 conda activate xlstm
 ``` 
 
-For the xLSTM Large 7B model we require our [`mlstm_kernels`](https://github.com/NX-AI/mlstm_kernels) package, which provides fast kernels for the xLSTM.
+The optional dependencies for the xLSTM Large 7B model include our [`mlstm_kernels`](https://github.com/NX-AI/mlstm_kernels) package, which provides fast kernels for the xLSTM.
 
 <div align="center">
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,14 @@ classifiers = [
 keywords = ["LSTM", "Transformer", "Machine Learning", "Deep Learning", "State Space Models"]
 dependencies = [
     "torch>=2.0",
-    "omegaconf",
-    "safetensors",
     "packaging",
     "ninja",
+]
+
+[project.optional-dependencies]
+large = [
+    "omegaconf",
+    "safetensors",
     "mlstm_kernels; python_version >= '3.11'",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1828,22 +1828,27 @@ name = "xlstm"
 version = "2.0.5"
 source = { editable = "." }
 dependencies = [
-    { name = "mlstm-kernels", marker = "python_full_version >= '3.11'" },
     { name = "ninja" },
-    { name = "omegaconf" },
     { name = "packaging" },
-    { name = "safetensors" },
     { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
+[package.optional-dependencies]
+large = [
+    { name = "mlstm-kernels", marker = "python_full_version >= '3.11'" },
+    { name = "omegaconf" },
+    { name = "safetensors" },
+]
+
 [package.metadata]
 requires-dist = [
-    { name = "mlstm-kernels", marker = "python_full_version >= '3.11'" },
+    { name = "mlstm-kernels", marker = "python_full_version >= '3.11' and extra == 'large'" },
     { name = "ninja" },
-    { name = "omegaconf" },
+    { name = "omegaconf", marker = "extra == 'large'" },
     { name = "packaging" },
-    { name = "safetensors" },
+    { name = "safetensors", marker = "extra == 'large'" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32'", specifier = ">=2.0" },
     { name = "torch", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu126" },
 ]
+provides-extras = ["large"]

--- a/xlstm/xlstm_large/model.py
+++ b/xlstm/xlstm_large/model.py
@@ -11,7 +11,9 @@ try:
         BackendModeType,
     )
 except ImportError:
-    raise ImportError("Please install mlstm_kernels package to use mLSTM block.")
+    raise ImportError(
+        'Please install xlstm with the "large" optional dependencies to use xLSTM Large: pip install "xlstm[large]".'
+    )
 
 
 import torch


### PR DESCRIPTION
## Summary
- move omegaconf, safetensors, and mlstm_kernels into a large optional extra
- document base and xLSTM Large installation commands
- direct missing-kernel errors to the large extra
- refresh the uv lockfile

## Validation
- uv lock --check
- verified base dependency export excludes Large-only packages and the large export includes them
- verified core xlstm import without Large dependencies
- compiled all Python sources

CUDA tests were not run because no GPU is available.

Closes #132