### PR TITLE
CI: add PyPI publishing workflow and bump version to 2.0.6

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,58 @@
+# https://docs.github.com/en/actions/tutorials/build-and-test-code/python#publishing-to-pypi
+
+name: Publish Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build release distributions
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+
+    needs:
+      - release-build
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mlstm-kernels/
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v5
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,7 +45,7 @@ jobs:
     # Dedicated environments with protections for publishing are strongly recommended.
     environment:
       name: pypi
-      url: https://pypi.org/p/mlstm-kernels/
+      url: https://pypi.org/p/xlstm/
 
     steps:
       - name: Retrieve release distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "xlstm"
-version = "2.0.5"
+version = "2.0.6"
 authors = [
   { name="Maximilian Beck", email="beck@ml.jku.at" },
   { name="Korbinian Poeppel", email="poeppel@ml.jku.at" },

--- a/xlstm/__init__.py
+++ b/xlstm/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 
 from .blocks.mlstm.block import mLSTMBlock, mLSTMBlockConfig
 from .blocks.mlstm.layer import mLSTMLayer, mLSTMLayerConfig


### PR DESCRIPTION
Adds a GitHub Actions workflow to build and publish xlstm distributions to PyPI when a release is published or the workflow is manually dispatched, and bumps the package version from 2.0.5 to 2.0.6 in both package metadata and `xlstm.__version__`.

The workflow builds with Python 3.11, transfers distributions between jobs as an artifact, and uses trusted publishing through the `pypi` environment. The environment links to the xlstm PyPI project.

Validation: whitespace checks passed, and both version declarations were verified to match 2.0.6. The publishing workflow has not been run.
