### PR TITLE
Fix publishing to build a pure-Python wheel

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,11 @@ jobs:
       - name: Build release distributions
         run: |
           python -m pip install build
-          python -m build
+          # Build a pure-Python wheel; CUDA extensions are compiled at runtime.
+          python -m build \
+            -Cwheel.cmake=false \
+            -Cwheel.py-api=py3 \
+            -Cwheel.platlib=false
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The release workflow currently invokes the default CMake wheel build. Configure publishing to build a pure-Python wheel, since CUDA extensions are compiled at runtime.

Pass `wheel.cmake=false`, `wheel.py-api=py3`, and `wheel.platlib=false` to the build backend.

Validation: `git diff --check` passed. A release build was not run locally because the Python `build` module is unavailable.
